### PR TITLE
Fix missing device for pphy2mlog tensor

### DIFF
--- a/eplb.py
+++ b/eplb.py
@@ -122,7 +122,8 @@ def rebalance_experts_hierarchical(weight: torch.Tensor, num_physical_experts: i
 
     pphy2mlog = phy2mlog.gather(-1, pphy2phy) # [num_layers * num_nodes, num_log_per_nodes]
     pphy2mlog = (pphy2mlog.view(num_layers, num_nodes, -1) + 
-                 torch.arange(0, num_logical_experts, num_logical_experts // num_nodes).view(1, -1, 1)).flatten(-2)
+                 torch.arange(0, num_logical_experts, num_logical_experts // num_nodes,
+                              device=group_pack_index.device).view(1, -1, 1)).flatten(-2)
     pphy2log = mlog2log.gather(-1, pphy2mlog)
     pphyrank = phyrank.gather(-1, pphy2phy).view(num_layers, -1)
     logcnt = mlogcnt.view(num_layers, -1).gather(-1, log2mlog)


### PR DESCRIPTION
When running EPLB during model init, it crashes "Expected all tensors to be on the same device, but found at least two devices":
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/4ca0b336-29f8-45ab-860d-b3a9848d29ea" />
